### PR TITLE
feat(web): add pricing page and update navigation links to include pricing

### DIFF
--- a/apps/web/src/app/pricing/page.tsx
+++ b/apps/web/src/app/pricing/page.tsx
@@ -1,0 +1,84 @@
+"use client"
+
+import React from "react"
+import Link from "next/link"
+import {Check} from "lucide-react"
+
+function Feature({ name }: { name: string }) {
+  return (
+    <li className="flex items-center gap-5 fill-primary">
+      <Check />
+      <span>{name}</span>
+    </li>
+  )
+}
+
+function Features({ names }: { names: string[] }) {
+  return (
+    <ul>
+      {names.map((name) => (
+        <Feature key={name} name={name} />
+      ))}
+    </ul>
+  )
+}
+
+const starter = [
+  "Simple AI",
+  "Chatger",
+]
+const pro = [
+  "Everything in Starter",
+  "Feedback from Chatger TA",
+  "Daily / Weekly / Yearly Stats",
+  "Priority Support",
+]
+
+
+function Pricing() {
+  return (
+    <div
+      className="mt-16 flex w-full flex-col items-center justify-center gap-10 sm:flex-row sm:items-stretch"
+    >
+      <div
+        className="flex w-[90%] flex-col gap-10 rounded-xl bg-secondary p-10 sm:w-2/5"
+      >
+        <div className="flex flex-col gap-2">
+          <h2 className="text-2xl">Starter</h2>
+          <div className="flex items-end gap-1">
+            <h2 className="text-4xl font-semibold">$0</h2>
+            <div className="text-sm opacity-50">/ forever</div>
+          </div>
+        </div>
+        <Link
+          href="/#"
+          className="cursor-pointer rounded-md border border-primary p-2
+        text-center font-semibold"
+        >
+          Get started
+        </Link>
+        <Features names={starter} />
+      </div>
+      <div
+        className="flex w-[90%] flex-col gap-10 rounded-xl bg-secondary p-10 sm:w-2/5"
+      >
+        <div className="flex flex-col gap-2">
+          <h2 className="text-2xl">Pro</h2>
+          <div className="flex items-end gap-1">
+            <h2 className="text-4xl font-semibold">$5</h2>
+            <div className="text-sm opacity-50">/ month</div>
+          </div>
+        </div>
+        <Link
+          href="/#"
+          className="rounded-md bg-primary p-2 text-center font-semibold text-secondary"
+        >
+          Get started
+        </Link>
+        <Features names={pro} />
+      </div>
+    </div>
+  )
+}
+
+export default Pricing

--- a/apps/web/src/components/header.tsx
+++ b/apps/web/src/components/header.tsx
@@ -24,8 +24,13 @@ function Header() {
         </Link>
         <nav className="flex-1 flex justify-center mt-2">
           <div className="gap-10 text-lg font-medium hidden sm:flex">
-            <a href="/#">Pricing</a>
-            <a href="https://refinaid-docs.vercel.app">Guestbook</a>
+            <Link href="/pricing">Pricing</Link>
+            <Link
+              href="https://refinaid-docs.vercel.app"
+              target='_blank'
+              rel='noreferrer noopener'
+              aria-label='GitHub'
+            >Guestbook</Link>
           </div>
         </nav>
         <div className="flex items-center space-x-4 mt-2">

--- a/apps/web/src/components/user-nav.tsx
+++ b/apps/web/src/components/user-nav.tsx
@@ -70,7 +70,7 @@ export function UserNav() {
         <DropdownMenuSeparator className="sm:hidden" />
         <DropdownMenuGroup className="sm:hidden">
           <DropdownMenuItem className="hover:cursor-pointer" asChild>
-            <Link href="/#" className="flex items-center">
+            <Link href="/pricing" className="flex items-center">
               <CreditCard className="w-4 h-4 mr-3 text-muted-foreground" />
               Pricing
             </Link>


### PR DESCRIPTION
This pull request introduces a new pricing page to the web application and updates the navigation links to point to the new page. The most important changes include the addition of the `Pricing` component and modifications to the header and user navigation components.

### New Pricing Page:

* [`apps/web/src/app/pricing/page.tsx`](diffhunk://#diff-49cff1cba611107f95ac7b6b85538e693a1f5446bf95932c9c3d2f9ad88919caR1-R84): Added a new `Pricing` component that includes the pricing details for the "Starter" and "Pro" plans. The component also includes `Feature` and `Features` sub-components to list the features of each plan.

### Navigation Updates:

* [`apps/web/src/components/header.tsx`](diffhunk://#diff-52fcdcdf38835ab718a83237d90f42a60b5bedb392e7417721a84e1cd3a4cee9L27-R33): Updated the navigation links in the `Header` component to use `Link` from `next/link` for the "Pricing" and "Guestbook" links. The "Guestbook" link now opens in a new tab with appropriate `rel` attributes for security.
* [`apps/web/src/components/user-nav.tsx`](diffhunk://#diff-b1d94d98abbe7b3a7cf93a241c0b42228ad280976a5fe8f305866c8d0353f64cL73-R73): Updated the "Pricing" link in the `UserNav` component to point to the new pricing page.