### PR TITLE
chore(deps): replace framer-motion with motion and update TypeScript reference link

### DIFF
--- a/apps/landing/next-env.d.ts
+++ b/apps/landing/next-env.d.ts
@@ -2,4 +2,4 @@
 /// <reference types="next/image-types/global" />
 
 // NOTE: This file should not be edited
-// see https://nextjs.org/docs/app/building-your-application/configuring/typescript for more information.
+// see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/apps/landing/package.json
+++ b/apps/landing/package.json
@@ -21,9 +21,9 @@
     "daisyui": "^4.12.23",
     "eslint": "9.19.0",
     "eslint-config-next": "15.1.6",
-    "framer-motion": "^12.0.6",
     "lucide": "^0.474.0",
     "lucide-react": "^0.475.0",
+    "motion": "12.0.5",
     "next": "15.1.6",
     "next-sitemap": "^4.1.8",
     "postcss": "8.5.1",
@@ -35,8 +35,8 @@
     "typescript": "5.7.3"
   },
   "devDependencies": {
-    "prettier": "3.4.2",
     "eslint-config-prettier": "^10.0.1",
+    "prettier": "3.4.2",
     "prettier-plugin-tailwindcss": "^0.6.8"
   }
 }

--- a/apps/landing/src/components/header.tsx
+++ b/apps/landing/src/components/header.tsx
@@ -4,7 +4,7 @@ import React, { useEffect, useState } from "react";
 import { FaDiscord, FaGithub, FaTwitter, FaBook } from "react-icons/fa";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
-import { motion } from "framer-motion";
+import { motion } from "motion/react"
 import Image from "next/image";
 
 const navigations = [

--- a/apps/landing/src/components/home-animations/home-buttons.tsx
+++ b/apps/landing/src/components/home-animations/home-buttons.tsx
@@ -1,7 +1,7 @@
 "use client";
 import Link from "next/link";
 import { HeartIcon, MarkGithubIcon, ArrowUpRightIcon } from "@primer/octicons-react";
-import { motion } from "framer-motion";
+import { motion } from "motion/react"
 
 const containerVariants = {
   initial: {

--- a/apps/landing/src/components/home-animations/home-team-person.tsx
+++ b/apps/landing/src/components/home-animations/home-team-person.tsx
@@ -1,5 +1,10 @@
 "use client";
-import { motion, useInView, useAnimation, Variants } from "framer-motion";
+import {
+  motion,
+  useInView,
+  useAnimation,
+  Variants,
+} from "motion/react";
 import { useEffect, useRef } from "react";
 import Image from "next/image";
 import Link from "next/link";

--- a/apps/landing/src/components/home-animations/home-team-title.tsx
+++ b/apps/landing/src/components/home-animations/home-team-title.tsx
@@ -1,5 +1,11 @@
 "use client";
-import { motion, useInView, useAnimation, Variants } from "framer-motion";
+
+import {
+  motion,
+  useInView,
+  useAnimation,
+  Variants,
+} from "motion/react";
 import { useEffect, useRef } from "react";
 
 export default function HomeTeamTitle({

--- a/apps/landing/src/components/home-animations/home-title.tsx
+++ b/apps/landing/src/components/home-animations/home-title.tsx
@@ -1,5 +1,5 @@
 "use client";
-import { motion } from "framer-motion";
+import { motion } from "motion/react";
 import { useEffect, useState } from "react";
 
 const containerVariants = {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -78,15 +78,15 @@ importers:
       eslint-config-next:
         specifier: 15.1.6
         version: 15.1.6(eslint@9.19.0(jiti@1.21.7))(typescript@5.7.3)
-      framer-motion:
-        specifier: ^12.0.6
-        version: 12.0.6(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       lucide:
         specifier: ^0.474.0
         version: 0.474.0
       lucide-react:
         specifier: ^0.475.0
         version: 0.475.0(react@18.2.0)
+      motion:
+        specifier: 12.0.5
+        version: 12.0.5(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       next:
         specifier: 15.1.6
         version: 15.1.6(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
@@ -2819,20 +2819,6 @@ packages:
 
   fraction.js@4.3.7:
     resolution: {integrity: sha512-ZsDfxO51wGAXREY55a7la9LScWpwv9RxIrYABrlvOFBlH/ShPnrtsXeuUIfXKKOVicNxQ+o8JTbJvjS4M89yew==}
-
-  framer-motion@12.0.5:
-    resolution: {integrity: sha512-OgfUHfL+u80uCf6VzkV7j3+H2W9zPMdV+40bug4ftB0C2+0FpfNca2rbH2Fouq2R7//bjw6tJhOwXsrsM4+LKw==}
-    peerDependencies:
-      '@emotion/is-prop-valid': '*'
-      react: ^18.0.0 || ^19.0.0
-      react-dom: ^18.0.0 || ^19.0.0
-    peerDependenciesMeta:
-      '@emotion/is-prop-valid':
-        optional: true
-      react:
-        optional: true
-      react-dom:
-        optional: true
 
   framer-motion@12.0.6:
     resolution: {integrity: sha512-LmrXbXF6Vv5WCNmb+O/zn891VPZrH7XbsZgRLBROw6kFiP+iTK49gxTv2Ur3F0Tbw6+sy9BVtSqnWfMUpH+6nA==}
@@ -7748,8 +7734,8 @@ snapshots:
       '@typescript-eslint/parser': 7.18.0(eslint@9.19.0(jiti@1.21.7))(typescript@5.7.3)
       eslint: 9.19.0(jiti@1.21.7)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.7.0(eslint-plugin-import@2.31.0)(eslint@9.19.0(jiti@1.21.7))
-      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@7.18.0(eslint@9.19.0(jiti@1.21.7))(typescript@5.7.3))(eslint@9.19.0(jiti@1.21.7))
+      eslint-import-resolver-typescript: 3.7.0(eslint-plugin-import@2.31.0(@typescript-eslint/parser@7.18.0(eslint@9.19.0(jiti@1.21.7))(typescript@5.7.3))(eslint@9.19.0(jiti@1.21.7)))(eslint@9.19.0(jiti@1.21.7))
+      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@7.18.0(eslint@9.19.0(jiti@1.21.7))(typescript@5.7.3))(eslint-import-resolver-typescript@3.7.0(eslint-plugin-import@2.31.0(@typescript-eslint/parser@7.18.0(eslint@9.19.0(jiti@1.21.7))(typescript@5.7.3))(eslint@9.19.0(jiti@1.21.7)))(eslint@9.19.0(jiti@1.21.7)))(eslint@9.19.0(jiti@1.21.7))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.19.0(jiti@1.21.7))
       eslint-plugin-react: 7.37.4(eslint@9.19.0(jiti@1.21.7))
       eslint-plugin-react-hooks: 5.1.0(eslint@9.19.0(jiti@1.21.7))
@@ -7785,6 +7771,22 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  eslint-import-resolver-typescript@3.7.0(eslint-plugin-import@2.31.0(@typescript-eslint/parser@7.18.0(eslint@9.19.0(jiti@1.21.7))(typescript@5.7.3))(eslint@9.19.0(jiti@1.21.7)))(eslint@9.19.0(jiti@1.21.7)):
+    dependencies:
+      '@nolyfill/is-core-module': 1.0.39
+      debug: 4.4.0
+      enhanced-resolve: 5.18.0
+      eslint: 9.19.0(jiti@1.21.7)
+      fast-glob: 3.3.3
+      get-tsconfig: 4.9.0
+      is-bun-module: 1.3.0
+      is-glob: 4.0.3
+      stable-hash: 0.0.4
+    optionalDependencies:
+      eslint-plugin-import: 2.31.0(@typescript-eslint/parser@7.18.0(eslint@9.19.0(jiti@1.21.7))(typescript@5.7.3))(eslint-import-resolver-typescript@3.7.0(eslint-plugin-import@2.31.0(@typescript-eslint/parser@7.18.0(eslint@9.19.0(jiti@1.21.7))(typescript@5.7.3))(eslint@9.19.0(jiti@1.21.7)))(eslint@9.19.0(jiti@1.21.7)))(eslint@9.19.0(jiti@1.21.7))
+    transitivePeerDependencies:
+      - supports-color
+
   eslint-import-resolver-typescript@3.7.0(eslint-plugin-import@2.31.0)(eslint@9.19.0(jiti@1.21.7)):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
@@ -7801,14 +7803,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.0(@typescript-eslint/parser@7.18.0(eslint@9.19.0(jiti@1.21.7))(typescript@5.7.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.7.0)(eslint@9.19.0(jiti@1.21.7)):
+  eslint-module-utils@2.12.0(@typescript-eslint/parser@7.18.0(eslint@9.19.0(jiti@1.21.7))(typescript@5.7.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.7.0(eslint-plugin-import@2.31.0(@typescript-eslint/parser@7.18.0(eslint@9.19.0(jiti@1.21.7))(typescript@5.7.3))(eslint@9.19.0(jiti@1.21.7)))(eslint@9.19.0(jiti@1.21.7)))(eslint@9.19.0(jiti@1.21.7)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 7.18.0(eslint@9.19.0(jiti@1.21.7))(typescript@5.7.3)
       eslint: 9.19.0(jiti@1.21.7)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.7.0(eslint-plugin-import@2.31.0)(eslint@9.19.0(jiti@1.21.7))
+      eslint-import-resolver-typescript: 3.7.0(eslint-plugin-import@2.31.0(@typescript-eslint/parser@7.18.0(eslint@9.19.0(jiti@1.21.7))(typescript@5.7.3))(eslint@9.19.0(jiti@1.21.7)))(eslint@9.19.0(jiti@1.21.7))
     transitivePeerDependencies:
       - supports-color
 
@@ -7828,7 +7830,7 @@ snapshots:
       eslint: 9.19.0(jiti@1.21.7)
       ignore: 5.3.2
 
-  eslint-plugin-import@2.31.0(@typescript-eslint/parser@7.18.0(eslint@9.19.0(jiti@1.21.7))(typescript@5.7.3))(eslint@9.19.0(jiti@1.21.7)):
+  eslint-plugin-import@2.31.0(@typescript-eslint/parser@7.18.0(eslint@9.19.0(jiti@1.21.7))(typescript@5.7.3))(eslint-import-resolver-typescript@3.7.0(eslint-plugin-import@2.31.0(@typescript-eslint/parser@7.18.0(eslint@9.19.0(jiti@1.21.7))(typescript@5.7.3))(eslint@9.19.0(jiti@1.21.7)))(eslint@9.19.0(jiti@1.21.7)))(eslint@9.19.0(jiti@1.21.7)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.8
@@ -7839,7 +7841,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.19.0(jiti@1.21.7)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.0(@typescript-eslint/parser@7.18.0(eslint@9.19.0(jiti@1.21.7))(typescript@5.7.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.7.0)(eslint@9.19.0(jiti@1.21.7))
+      eslint-module-utils: 2.12.0(@typescript-eslint/parser@7.18.0(eslint@9.19.0(jiti@1.21.7))(typescript@5.7.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.7.0(eslint-plugin-import@2.31.0(@typescript-eslint/parser@7.18.0(eslint@9.19.0(jiti@1.21.7))(typescript@5.7.3))(eslint@9.19.0(jiti@1.21.7)))(eslint@9.19.0(jiti@1.21.7)))(eslint@9.19.0(jiti@1.21.7))
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -8230,15 +8232,6 @@ snapshots:
 
   fraction.js@4.3.7: {}
 
-  framer-motion@12.0.5(react-dom@19.0.0(react@19.0.0))(react@19.0.0):
-    dependencies:
-      motion-dom: 12.0.0
-      motion-utils: 12.0.0
-      tslib: 2.8.1
-    optionalDependencies:
-      react: 19.0.0
-      react-dom: 19.0.0(react@19.0.0)
-
   framer-motion@12.0.6(react-dom@18.2.0(react@18.2.0))(react@18.2.0):
     dependencies:
       motion-dom: 12.0.0
@@ -8247,6 +8240,15 @@ snapshots:
     optionalDependencies:
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
+
+  framer-motion@12.0.6(react-dom@19.0.0(react@19.0.0))(react@19.0.0):
+    dependencies:
+      motion-dom: 12.0.0
+      motion-utils: 12.0.0
+      tslib: 2.8.1
+    optionalDependencies:
+      react: 19.0.0
+      react-dom: 19.0.0(react@19.0.0)
 
   fs-extra@10.1.0:
     dependencies:
@@ -9610,9 +9612,17 @@ snapshots:
 
   motion-utils@12.0.0: {}
 
+  motion@12.0.5(react-dom@18.2.0(react@18.2.0))(react@18.2.0):
+    dependencies:
+      framer-motion: 12.0.6(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      tslib: 2.8.1
+    optionalDependencies:
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+
   motion@12.0.5(react-dom@19.0.0(react@19.0.0))(react@19.0.0):
     dependencies:
-      framer-motion: 12.0.5(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      framer-motion: 12.0.6(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       tslib: 2.8.1
     optionalDependencies:
       react: 19.0.0


### PR DESCRIPTION
This pull request updates dependencies and replaces the `framer-motion` library with the `motion` library across various components. The most important changes include modifications to the `package.json` and `pnpm-lock.yaml` files, as well as updates to several React components to use the new `motion` library.

Dependency updates:

* [`apps/landing/package.json`](diffhunk://#diff-36576d6b9c7a585a28cb70bef503e17feb1ae662609245b81b4c0ed3054b7509L24-R26): Replaced `framer-motion` with `motion` and adjusted the version of `prettier`. [[1]](diffhunk://#diff-36576d6b9c7a585a28cb70bef503e17feb1ae662609245b81b4c0ed3054b7509L24-R26) [[2]](diffhunk://#diff-36576d6b9c7a585a28cb70bef503e17feb1ae662609245b81b4c0ed3054b7509L38-R39)

Component updates:

* [`apps/landing/src/components/header.tsx`](diffhunk://#diff-b1a6d5a2f21ca87fe3b192bc9ed5332842cb9e71f8c9e3fd67711a60ddc90c51L7-R7): Updated import statement to use `motion` from `motion/react`.
* [`apps/landing/src/components/home-animations/home-buttons.tsx`](diffhunk://#diff-193cc0cb95179569e511b3f0a00e4192dc8187bdc3835a58fc6a7377c607ba26L4-R4): Updated import statement to use `motion` from `motion/react`.
* [`apps/landing/src/components/home-animations/home-team-person.tsx`](diffhunk://#diff-7e89b5e9d1162f92ecedd7bbbe3789c5e8162cf7cf71d5b40715f09bba0439c0L2-R7): Updated import statement to use `motion` from `motion/react`.
* [`apps/landing/src/components/home-animations/home-team-title.tsx`](diffhunk://#diff-e2851dca25843e7f87973508f7ea099e5a3ec5f49937822310df931c1b866ebeL2-R8): Updated import statement to use `motion` from `motion/react`.
* [`apps/landing/src/components/home-animations/home-title.tsx`](diffhunk://#diff-880eb05a03113144de918ccbe19541db4f976c4c5a4b064773c4486ebda2c098L2-R2): Updated import statement to use `motion` from `motion/react`.

Lock file updates:

* [`pnpm-lock.yaml`](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL81-R89): Removed `framer-motion` and added `motion` with the corresponding dependency adjustments. [[1]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL81-R89) [[2]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL2823-L2836) [[3]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL7751-R7738) [[4]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR7774-R7789) [[5]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL7804-R7813) [[6]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL7831-R7833) [[7]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL7842-R7844) [[8]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL8233-R8251) [[9]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbR9615-R9625)